### PR TITLE
Providing a clickable link to a site report Permalink

### DIFF
--- a/BlockedFrontend/templates/blocked-eu/site.html
+++ b/BlockedFrontend/templates/blocked-eu/site.html
@@ -216,22 +216,18 @@
   </div>
 
   <div class="col-md-6">
-    <h4>Link to this result</h4>
-    <form class="form-horizontal">
-      <div class="form-group">
-        <div class="col-sm-12">
-          <div class="input-group">
-            <input class="form-control" type="text" id="permalink" name="permalink" value="{{ config.SITE_URL }}{{  url_for('.site', url=url)  }}">
-            <span class="input-group-btn">
-              <button title="Copy this permalink to the clipboard" id="copybtn" class="btn btn-default" type="button"><span class="glyphicon glyphicon-copy"></span></button>
-            </span>
-          </div>
-        </div>
-      </div>
-    </form>
-
-
-  </div>
+		<h4>Link to this result</h4>
+	<small><a href="{{ config.SITE_URL }}{{  url_for('.site', url=url)  }}">{{ config.SITE_URL }}{{  url_for('.site', url=url)  }}</a></small>
+				  <button title="Copy this permalink to the clipboard" id="copybtn" type="button" class="btn btn-default" style="margin-left: 1.5rem;"><span class="glyphicon glyphicon-copy"></span></button>
+		
+		<h4>Related results</h4>
+		
+		<div id="categorylist">This site is listed in the <span>PG</span> and <span>Technology</span> categories.</div>
+		
+		<p><small><em>Category information provided by <a href="https://categorify.org" target="_blank">Categorify</a> and <a href="https://dmoztools.net" target="_blank">dmoztools.net</a></em></small></p>
+		
+	
+</div>
 
 </div> <!-- /.row -->
 

--- a/BlockedFrontend/templates/site/site.html
+++ b/BlockedFrontend/templates/site/site.html
@@ -297,7 +297,7 @@ Your feedback was successfully submitted.
   <div class="col-md-6">
 		<h4>Link to this result</h4>
 	<small><a href="{{ config.SITE_URL }}{{  url_for('.site', url=url)  }}">{{ config.SITE_URL }}{{  url_for('.site', url=url)  }}</a></small>
-				  <button title="Copy this permalink to the clipboard" id="copybtn" type="button" class="btn btn-default" style="margin-left: 10px;"><span class="glyphicon glyphicon-copy"></span></button>
+				  <button title="Copy this permalink to the clipboard" id="copybtn" type="button" class="btn btn-default" style="margin-left: 1.5rem;"><span class="glyphicon glyphicon-copy"></span></button>
 		
 		<h4>Related results</h4>
 		
@@ -333,4 +333,3 @@ Your feedback was successfully submitted.
 </div>
 
 {% endblock %}
-

--- a/BlockedFrontend/templates/site/site.html
+++ b/BlockedFrontend/templates/site/site.html
@@ -295,35 +295,18 @@ Your feedback was successfully submitted.
   </div>
 
   <div class="col-md-6">
-    <h4>Link to this result</h4>
-    <form class="form-horizontal">
-      <div class="form-group">
-        <div class="col-sm-12">
-          <div class="input-group">
-            <input class="form-control" type="text" id="permalink" name="permalink" value="{{ config.SITE_URL }}{{  url_for('.site', url=url)  }}">
-            <span class="input-group-btn">
-              <button title="Copy this permalink to the clipboard" id="copybtn" class="btn btn-default" type="button"><span class="glyphicon glyphicon-copy"></span></button>
-            </span>
-          </div>
-        </div>
-      </div>
-    </form>
-    <h4>Related results</h4>
-    {% if alt_url_data %}
-    <p><a href="{{ url_for('.site', url=url.replace('http:','https:')) }}">View results for the HTTPS version of this site.</a></p>
-    {% endif %}
-
-    {% if savedlist and not live and config.MODULE_SAVEDLIST %}
-    <div>This site appears on the <a href="{{ url_for('list.show_list', name=savedlist.name) }}">{{ savedlist.name }}</a> user-created list.</div>
-    {% endif %}
-
-    {% if categories %}
-    <div id="categorylist">This site is listed in the {{ categories|join_en(markup=True)|safe }} categor{{ 'y' if categories|length == 1 else 'ies' }}.</div>
-    
-    <p><small><em>Category information provided by <a href="https://categorify.org" target="_blank">Categorify</a> and <a href="https://dmoztools.net" target="_blank">dmoztools.net</a></em></small></p>
-    {% endif %}
-
-  </div>
+		<h4>Link to this result</h4>
+	<small><a href="{{ config.SITE_URL }}{{  url_for('.site', url=url)  }}">{{ config.SITE_URL }}{{  url_for('.site', url=url)  }}</a></small>
+				  <button title="Copy this permalink to the clipboard" id="copybtn" type="button" class="btn btn-default" style="margin-left: 10px;"><span class="glyphicon glyphicon-copy"></span></button>
+		
+		<h4>Related results</h4>
+		
+		<div id="categorylist">This site is listed in the <span>PG</span> and <span>Technology</span> categories.</div>
+		
+		<p><small><em>Category information provided by <a href="https://categorify.org" target="_blank">Categorify</a> and <a href="https://dmoztools.net" target="_blank">dmoztools.net</a></em></small></p>
+		
+	
+	  </div>
 
 </div> <!-- /.row -->
 


### PR DESCRIPTION
When I check a URL on the Blocked frontend, I find I often want to open the permalink in a new tab. This takes longer than it should at the moment.

This is what the interface currently looks like. You have to know what the copy to clipboard symbol means, click on it, then click in the address bar, then tap enter. It's not clear why this would be a form rather than a link.

<img width="576" alt="screenshot 2019-03-07 at 11 57 10" src="https://user-images.githubusercontent.com/6547979/53955168-2b93ea00-40d0-11e9-8562-5b76c724c273.png">

My PR would mean the user only has to be able to recognise a link and click on it to get to the permalink.

<img width="403" alt="screenshot 2019-03-07 at 12 02 09" src="https://user-images.githubusercontent.com/6547979/53955411-ddcbb180-40d0-11e9-80d5-bb72d21cb3e4.png">
